### PR TITLE
Bug Fix: sidebar disappears while at medium screen width & visual consistency

### DIFF
--- a/main.php
+++ b/main.php
@@ -228,7 +228,7 @@ switch ($bootstrapTheme){
         <!-- ********** ASIDE ********** -->
         <div id="dokuwiki__aside" class="col-sm-3 col-md-2">
           <div class="content">
-            <div class="toogle hidden-print hidden-lg" data-toggle="collapse" data-target="#dokuwiki__aside .collapse">
+            <div class="toogle hidden-print panel-heading panel" data-toggle="collapse" data-target="#dokuwiki__aside .collapse">
               <i class="glyphicon glyphicon-th-list"></i> <?php echo $lang['sidebar'] ?>
             </div>
             <div class="collapse in">

--- a/main.php
+++ b/main.php
@@ -228,7 +228,7 @@ switch ($bootstrapTheme){
         <!-- ********** ASIDE ********** -->
         <div id="dokuwiki__aside" class="col-sm-3 col-md-2">
           <div class="content">
-            <div class="toogle hidden-print hidden-lg hidden-md" data-toggle="collapse" data-target="#dokuwiki__aside .collapse">
+            <div class="toogle hidden-print hidden-lg" data-toggle="collapse" data-target="#dokuwiki__aside .collapse">
               <i class="glyphicon glyphicon-th-list"></i> <?php echo $lang['sidebar'] ?>
             </div>
             <div class="collapse in">

--- a/script.js
+++ b/script.js
@@ -32,17 +32,16 @@ jQuery(document).ready(function() {
 
   function checkSize() {
 
-    if (   $screen_mode.find('.visible-xs').is(':visible')
-        || $screen_mode.find('.visible-sm').is(':visible')
-        || $screen_mode.find('.visible-md').is(':visible')) {
+    if (   $screen_mode.find('.visible-xs').is(':visible')) {
 
       $dw_aside.find('.content').addClass('panel panel-default');
-      $dw_aside.find('.toogle').addClass('panel-heading');
+      $dw_aside.find('.toogle').removeClass('panel');
       $dw_aside.find('.collapse').addClass('panel-body').removeClass('in');
 
     } else {
 
       $dw_aside.find('.content').removeClass('panel panel-default');
+      $dw_aside.find('.toogle').addClass('panel');
       $dw_aside.find('.collapse').removeClass('panel-body').addClass('in');
 
     }


### PR DESCRIPTION
I've done a few quick bugfixes for the sidebar.

Commit 992f2f6 is a straightforward fix for a missing sidebar at medium window-sizes:
![screen shot 2015-03-31 at 9 07 56 pm](https://cloud.githubusercontent.com/assets/119146/6933577/271ec54e-d7f7-11e4-9537-6ecdb5334131.png)

Commit ed60d43 is a bit more involved, but concerns:

1. keeping the sidebar visually consistent while resizing the window, as well as

2. disabling the automatic collapse of the sidebar when it is still to the side of the window.  (The xtra-small collapse behaviour was not modified.)

You can see a live version of the modifications here: http://www.scenic-shop.com/structure/doku.php/start

This is my first pull request, so I'm not sure if I should have put these in two separate ones or not.  If so, please just let me know.

Thanks for your time, and good job on the template, I really dig it.

