### PR TITLE
Show Tools option

### DIFF
--- a/conf/default.php
+++ b/conf/default.php
@@ -6,6 +6,7 @@
  * @license  GPL 2 (http://www.gnu.org/licenses/gpl.html)
  */
 
+$conf['showTools']         = 'always';
 $conf['sidebarPosition']   = 'left';
 $conf['rightSidebar']      = 'rightsidebar';
 $conf['showTranslation']   = 0;

--- a/conf/metadata.php
+++ b/conf/metadata.php
@@ -4,6 +4,7 @@
  *
  */
 
+$meta['showTools']         = array('multichoice', '_choices' => array('never', 'logged', 'always'));
 $meta['sidebarPosition']   = array('multichoice', '_choices' => array('left', 'right'));
 $meta['rightSidebar']      = array('string');
 $meta['showTranslation']   = array('onoff');

--- a/lang/en/settings.php
+++ b/lang/en/settings.php
@@ -6,6 +6,10 @@
  * @license  GPL 2 (http://www.gnu.org/licenses/gpl.html)
  */
 
+$lang['showTools']         = 'Display Tools in navbar';
+$lang['showTools_o_never'] = 'Never';
+$lang['showTools_o_logged'] = 'When logged in';
+$lang['showTools_o_always'] = 'Always';
 $lang['sidebarPosition']   = 'DokuWiki Sidebar position (<code>left</code> or <code>right</code>)';
 $lang['rightSidebar']      = '<strong>EXPERIMENTAL</strong> The Right Sidebar page name, empty field disables the right sidebar. The Right Sidebar is displayed only when the default DokuWiki <a href="#config___sidebar">sidebar</a> is enabled and is on the <code>left</code> position (see the <a href="#config___tpl____bootstrap3____sidebarPosition">
 tpl»bootstrap3»sidebarPosition</a> configuration). If do you want only the DokuWiki sidebar on right position, set the <a href="#config___tpl____bootstrap3____sidebarPosition">

--- a/lang/ja/settings.php
+++ b/lang/ja/settings.php
@@ -5,6 +5,10 @@
 * @author Hideaki SAWADA <chuno@live.jp>
 */
 
+$lang['showTools']     = 'navbar にツールを表示する';
+$lang['showTools_o_never'] = '表示しない';
+$lang['showTools_o_logged'] = 'ログインしたときに表示する';
+$lang['showTools_o_always'] = '常に表示する';
 $lang['inverseNavbar'] = 'navbar の色を反転する';
 $lang['fixedTopNavbar'] = 'navbar を上部に固定する';
 $lang['bootstrapTheme'] = 'テーマの選択（default Bootstrap テーマ・Bootstrap optional テーマ・Bootswatch.com テーマ・ custom テーマ）';

--- a/main.php
+++ b/main.php
@@ -11,7 +11,8 @@ if (!defined('DOKU_INC')) die(); /* must be run from within DokuWiki */
 @require_once(dirname(__FILE__).'/tpl_functions.php'); /* include hook for template functions */
 header('X-UA-Compatible: IE=edge,chrome=1');
 
-$showTools         = !tpl_getConf('hideTools') || ( tpl_getConf('hideTools') && !empty($_SERVER['REMOTE_USER']) );
+$showTools         = tpl_getConf('showTools') != 'never' &&
+                     ( tpl_getConf('showTools') == 'always' || !empty($_SERVER['REMOTE_USER']) );
 $showSidebar       = page_findnearest($conf['sidebar']) && ($ACT=='show');
 $sidebarPosition   = tpl_getConf('sidebarPosition');
 $showRightSidebar  = page_findnearest(tpl_getConf('rightSidebar')) && ($ACT=='show');

--- a/tpl_navbar.php
+++ b/tpl_navbar.php
@@ -36,6 +36,7 @@
 
         <?php tpl_searchform() ?>
 
+        <?php if ($showTools): ?>
         <ul class="nav navbar-nav">
           <li class="dropdown">
             <a href="#" class="dropdown-toggle" data-toggle="dropdown" title=""><i class="glyphicon glyphicon-wrench"></i> <?php echo $lang['tools']; ?> <span class="caret"></span></a>
@@ -102,6 +103,7 @@
             <?php echo tpl_action('login', 1, '', 1, '<i class="glyphicon glyphicon-log-'. (!empty($_SERVER['REMOTE_USER']) ? 'out' : 'in') .'"></i> ') ?>
           </li>
         </ul>
+        <?php endif ?>
 
       </div>
 

--- a/tpl_navbar.php
+++ b/tpl_navbar.php
@@ -77,6 +77,7 @@
             </ul>
           </li>
         </ul>
+        <?php endif ?>
 
         <?php if ($showThemeSwitcher && $bootstrapTheme == 'bootswatch'): ?>
         <!-- theme-switcher -->
@@ -103,7 +104,6 @@
             <?php echo tpl_action('login', 1, '', 1, '<i class="glyphicon glyphicon-log-'. (!empty($_SERVER['REMOTE_USER']) ? 'out' : 'in') .'"></i> ') ?>
           </li>
         </ul>
-        <?php endif ?>
 
       </div>
 


### PR DESCRIPTION
I am currently using this theme and I would like to be able to use as a CMS theme as well.

I used the already declared (but not used) `$showTools`, but I changed the conf name because I feel it was easier to get this way. English and Japanese translations included.

Currently I included the themeswitcher and login link on purpose, though it might have been better to find another name for this that includes everything. Or maybe I should just make another option to not display the login form.