### PR TITLE
Show login link option

### DIFF
--- a/conf/default.php
+++ b/conf/default.php
@@ -7,6 +7,7 @@
  */
 
 $conf['showTools']         = 'always';
+$conf['hideLoginLink']     = 0;
 $conf['sidebarPosition']   = 'left';
 $conf['rightSidebar']      = 'rightsidebar';
 $conf['showTranslation']   = 0;

--- a/conf/metadata.php
+++ b/conf/metadata.php
@@ -5,6 +5,7 @@
  */
 
 $meta['showTools']         = array('multichoice', '_choices' => array('never', 'logged', 'always'));
+$meta['hideLoginLink']     = array('onoff');
 $meta['sidebarPosition']   = array('multichoice', '_choices' => array('left', 'right'));
 $meta['rightSidebar']      = array('string');
 $meta['showTranslation']   = array('onoff');

--- a/lang/en/settings.php
+++ b/lang/en/settings.php
@@ -10,6 +10,7 @@ $lang['showTools']         = 'Display Tools in navbar';
 $lang['showTools_o_never'] = 'Never';
 $lang['showTools_o_logged'] = 'When logged in';
 $lang['showTools_o_always'] = 'Always';
+$lang['hideLoginLink']     = 'Hide Login link in navbar';
 $lang['sidebarPosition']   = 'DokuWiki Sidebar position (<code>left</code> or <code>right</code>)';
 $lang['rightSidebar']      = '<strong>EXPERIMENTAL</strong> The Right Sidebar page name, empty field disables the right sidebar. The Right Sidebar is displayed only when the default DokuWiki <a href="#config___sidebar">sidebar</a> is enabled and is on the <code>left</code> position (see the <a href="#config___tpl____bootstrap3____sidebarPosition">
 tpl»bootstrap3»sidebarPosition</a> configuration). If do you want only the DokuWiki sidebar on right position, set the <a href="#config___tpl____bootstrap3____sidebarPosition">

--- a/lang/fr/settings.php
+++ b/lang/fr/settings.php
@@ -6,6 +6,7 @@
  * @license  GPL 2 (http://www.gnu.org/licenses/gpl.html)
  */
 
+$lang['hideLoginLink']     = 'Cacher le lien vers le login dans la barre de navigation';
 $lang['sidebarPosition']   = 'Position de la sidebar de DokuWiki (<code>left</code> (gauche) ou <code>right</code> (droite))';
 $lang['rightSidebar']      = '<strong>EXPÉRIMENTAL</strong> Nom de la page pour la sidebar de droite. La sidebar de droite est affichée uniquement quand la sidebar de Dokuwiki est activée, et si celle-ci est placée à gauche (<code>left</code>), (voir <a href="#config___tpl___bootstrap3___sidebarPosition">tpl»bootstrap3»sidebarPosition</a>).  Si vous souhaitez uniquement la sidebar de droite, configurez <a href="#config___tpl____bootstrap3____sidebarPosition">tpl»bootstrap3»sidebarPosition</a> à <code>right</code> (droite).';
 $lang['showTranslation']   = 'Affiche la barre de langues (nécessite <em>Translation Plugin</em>)';

--- a/lang/ja/settings.php
+++ b/lang/ja/settings.php
@@ -9,6 +9,7 @@ $lang['showTools']     = 'navbar にツールを表示する';
 $lang['showTools_o_never'] = '表示しない';
 $lang['showTools_o_logged'] = 'ログインしたときに表示する';
 $lang['showTools_o_always'] = '常に表示する';
+$lang['hideLoginLink']      = 'navbar にログインを非表示する';
 $lang['inverseNavbar'] = 'navbar の色を反転する';
 $lang['fixedTopNavbar'] = 'navbar を上部に固定する';
 $lang['bootstrapTheme'] = 'テーマの選択（default Bootstrap テーマ・Bootstrap optional テーマ・Bootswatch.com テーマ・ custom テーマ）';

--- a/main.php
+++ b/main.php
@@ -13,6 +13,7 @@ header('X-UA-Compatible: IE=edge,chrome=1');
 
 $showTools         = tpl_getConf('showTools') != 'never' &&
                      ( tpl_getConf('showTools') == 'always' || !empty($_SERVER['REMOTE_USER']) );
+$showLoginLink     = !tpl_getConf('hideLoginLink') || !empty($_SERVER['REMOTE_USER']);
 $showSidebar       = page_findnearest($conf['sidebar']) && ($ACT=='show');
 $sidebarPosition   = tpl_getConf('sidebarPosition');
 $showRightSidebar  = page_findnearest(tpl_getConf('rightSidebar')) && ($ACT=='show');

--- a/tpl_navbar.php
+++ b/tpl_navbar.php
@@ -101,7 +101,9 @@
             } ?>
           </li>
           <li>
-            <?php echo tpl_action('login', 1, '', 1, '<i class="glyphicon glyphicon-log-'. (!empty($_SERVER['REMOTE_USER']) ? 'out' : 'in') .'"></i> ') ?>
+            <?php if ($showLoginLink) {
+              echo tpl_action('login', 1, '', 1, '<i class="glyphicon glyphicon-log-'. (!empty($_SERVER['REMOTE_USER']) ? 'out' : 'in') .'"></i> ');
+            } ?>
           </li>
         </ul>
 


### PR DESCRIPTION
To complete PR #9.
Defaults to not hide the login link. I thought it would be best to let the logout link displayed in anycase. I can use the same options used for the tools if you want. Translations en/fr/ja.