### PR TITLE
Fix icons on email links in navbar & sidebar

### DIFF
--- a/css/template.less
+++ b/css/template.less
@@ -281,6 +281,7 @@ nav {
       }
 
       a.urlextern,
+      a.mail,
       a.mediafile {
         padding-left: 28px;
         background-position: 8px center;
@@ -375,7 +376,7 @@ nav {
 
 
 /* External URL (navbar) */
-.navbar-nav a.urlextern {
+.navbar-nav a.urlextern, .navbar-nav a.mail {
   padding: 15px 0 15px 18px;
 }
 


### PR DESCRIPTION
a.mail has an icon like a.externallink, so there should also be an offset to avoid overlap between icon & text