### PR TITLE
Fix background color for active item in pagetools

### DIFF
--- a/css/template.less
+++ b/css/template.less
@@ -221,10 +221,10 @@ nav {
 
   ul li a {
     padding: 2px;
-
-    &:hover {
+  }
+  
+  ul li:not(.active) a:hover {
       background: transparent;
-    }
   }
 
   .tools {


### PR DESCRIPTION
Do not make menu item background transparent when hovering over the active item in the pagetools menu.
The active item has a blue background by default, but the background color disappears when hovering over the link.
Because the icon itself is white, it looks like the icon disappeared on hover.