### PR TITLE
Multi-colum custom DropDown menu IE overlap fix

### DIFF
--- a/css/template.less
+++ b/css/template.less
@@ -517,7 +517,7 @@ ul.btn-group {
 .dropdown-row {
 
   > ul {
-    position: initial;
+    position: static;
     border: 0px;
     box-shadow: initial;
   }


### PR DESCRIPTION
Changing position:initial to position:static fixes a menu overlap that is occurring in IE 11 without affecting the performance in Chrome.

I'm new at web development, so my apologies if this change is no good for reasons I may not foresee. I figured I'd share the fix instead of just updating my userstyle.css silently :) .

In IE before change:
![capture](https://cloud.githubusercontent.com/assets/16724278/13063371/4b5db2d8-d3fc-11e5-93e9-95791062114f.PNG)

After:
![capture2](https://cloud.githubusercontent.com/assets/16724278/13063380/6de8934a-d3fc-11e5-9386-acb363205732.PNG)
