### PR TITLE
Create a new hook to allow user to include a full view jumbotron to his pages

### DIFF
--- a/main.php
+++ b/main.php
@@ -34,6 +34,7 @@ header('X-UA-Compatible: IE=edge,chrome=1');
 <body class="<?php echo trim(implode(' ', $body_classes)) ?>">
 
   <header id="dokuwiki__header" class="dokuwiki container<?php echo (bootstrap3_is_fluid_container()) ? '-fluid' : '' ?>">
+    <?php require_once('tpl_jumbotron.php'); ?>
     <?php tpl_includeFile('topheader.html') ?>
     <?php require_once('tpl_navbar.php'); ?>
     <?php tpl_includeFile('header.html') ?>

--- a/main.php
+++ b/main.php
@@ -20,6 +20,7 @@ header('X-UA-Compatible: IE=edge,chrome=1');
   <title><?php echo bootstrap3_page_browser_title() ?></title>
   <script>(function(H){H.className=H.className.replace(/\bno-js\b/,'js')})(document.documentElement)</script>
   <meta name="viewport" content="width=device-width,initial-scale=1" />
+  <meta property="og:url" content="<?php echo wl($ID, "", 1); ?>">
   <?php echo tpl_favicon(array('favicon', 'mobile')) ?>
   <?php tpl_includeFile('meta.html') ?>
   <?php tpl_metaheaders() ?>

--- a/tpl_jumbotron.php
+++ b/tpl_jumbotron.php
@@ -1,0 +1,30 @@
+<?php
+/**
+ * DokuWiki Bootstrap3 Template: Jumbotron  hook
+ *
+ * @link     http://dokuwiki.org/template:bootstrap3
+ * @author   Eric Maeker <eric@@maeker.fr>
+ * @license  GPL 2 (http://www.gnu.org/licenses/gpl.html)
+ */
+
+  // must be run from within DokuWiki
+  if (!defined('DOKU_INC')) die();
+
+  // This jumbotron hook allow users to include full view jumbotron to their
+  // landing pages. Config vars: showLandingPage and landingPages must be defined accordingly.
+  // On landing pages, the jumbotron is included before the dokuwiki page. This allow user
+  // to create a beautifull "one picture" landing page to their website.
+
+  // Show jumbotron on landing pages only
+  if (bootstrap3_conf('showLandingPage')
+      && (bool) preg_match(bootstrap3_conf('landingPages'), $ID)) {
+       // Do not include jumbotron on administratives panels
+       if ($_GET['do'] == '') {
+         tpl_include_page('jumbotron', 1, 1);
+       } else {
+         // Here you can add a padding-top empty div
+       }
+  } else {
+    // Here you can add a padding-top empty div
+  }
+?>


### PR DESCRIPTION
On landing pages only, add a hook to
   jumbotron.txt (inside the namespace only)
Include this jumbotron content before the page to allow to create a full view jumbotron on landing pages.
See in action here: [https://www.maeker.fr](https://www.maeker.fr)
