### PR TITLE
Fixed logo alignment when not using a tagline

### DIFF
--- a/css/template.less
+++ b/css/template.less
@@ -138,12 +138,6 @@ header {
 }
 
 
-/* NavBar Logo */
-#dw__logo {
-  margin-top: -5px;
-}
-
-
 /* Badges */
 #dw__badges {
   margin-top: 50px;

--- a/tpl_navbar.php
+++ b/tpl_navbar.php
@@ -40,7 +40,7 @@ $navbar_classes[] = (bootstrap3_conf('inverseNavbar')  ? 'navbar-inverse'   : 'n
         $logo_size = 'height="20"';
 
         if ($tagline) {
-          $logo_size = 'height="32"';
+          $logo_size = 'height="32" style="margin-top:-5px"';
         }
 
         // display logo and wiki title in a link to the home page


### PR DESCRIPTION
This fixes the logo's vertical alignment when not using a tagline by moving `margin-top:-5px` back to tpl_navbar.php since it should only be applied when a tagline is present. (reverses 1d25329)