### PR TITLE
RFC Change Site Tools icon from Wrench to Cubes

### DIFF
--- a/tpl_functions.php
+++ b/tpl_functions.php
@@ -747,7 +747,7 @@ function bootstrap3_tools($add_icons = true) {
   );
 
   $tools['site'] = array(
-    'icon'    => 'fa fa-fw fa-wrench',
+    'icon'    => 'fa fa-fw fa-cubes',
     'actions' => array(
       'recent' => array('icon' => 'fa fa-fw fa-list-alt'),
       'media'  => array('icon' => 'fa fa-fw fa-picture-o'),


### PR DESCRIPTION
The wrench icon is already used by the Tools dropdown. The cubes icon feels appropriate.

Before:
* https://ptpb.pw/esRS.png
* https://ptpb.pw/YWaO.png with individualTools

After:
* https://ptpb.pw/YWaO.png
* https://ptpb.pw/I6im.png with individualTools