### PR TITLE
bootstrap3_metaheaders():  local CSS/JS additions to template

### DIFF
--- a/tpl_functions.php
+++ b/tpl_functions.php
@@ -1589,6 +1589,26 @@ function bootstrap3_metaheaders(Doku_Event &$event, $param) {
     'type' => 'text/javascript',
     'src'  => tpl_basedir() . 'assets/anchorjs/anchor.min.js');
 
+  // If there's a "local" directory in the "assets" directory, then
+  // look for .css and .js files to add:
+  if ( is_dir(tpl_incdir() . 'assets/local') ) {
+    if ( ($dirH = opendir(tpl_incdir() . 'assets/local')) ) {
+      while ( ($fname = readdir($dirH)) !== false ) {
+        if ( substr_compare($fname, '.css', -4, 4) == 0 ) {
+          $event->data['link'][] = array(
+            'type' => 'text/css',
+            'rel'  => 'stylesheet',
+            'href' => tpl_basedir() . 'assets/local/' . $fname);
+        }
+        else if ( substr_compare($fname, '.js', -3, 3) == 0 ) {
+          $event->data['script'][] = array(
+            'type' => 'text/javascript',
+            'src' => tpl_basedir() . 'assets/local/' . $fname);
+        }
+      }
+    }
+  }
+
 
   // Apply some FIX
   if ($ACT || defined('DOKU_MEDIADETAIL')) {

--- a/tpl_functions.php
+++ b/tpl_functions.php
@@ -1606,6 +1606,7 @@ function bootstrap3_metaheaders(Doku_Event &$event, $param) {
             'src' => tpl_basedir() . 'assets/local/' . $fname);
         }
       }
+      closedir($dirH);
     }
   }
 


### PR DESCRIPTION
We dislike the red-on-gray color of inline <code> tags that seems to pervade all Bootstrap themes.  We could edit the assets/bootstrap/*/*.css files, but that wouldn't help if we're using CSS from a CDN.  The "cascading" part of CSS has us wanting to augment the standard CSS provided with our own file(s).

This modification allows the Dokuwiki admin to create a directory named "local" inside the template's "assets" directory.  Any *.css and *.js files therein will have <link> and <script> tags added in the <head> _after_ the Bootstrap boilerplate CSS/JS tags.