### PR TITLE
Display Admin menu to Managers as well as Admins

### DIFF
--- a/tpl_functions.php
+++ b/tpl_functions.php
@@ -910,7 +910,7 @@ function bootstrap3_conf($key, $default = false) {
       return $value !== 'never' && ( $value == 'always' || ! empty($_SERVER['REMOTE_USER']) );
 
     case 'showAdminMenu':
-      return $value && $INFO['isadmin'];
+      return $value && ($INFO['isadmin'] || $INFO['ismanager']);
 
     case 'hideLoginLink':
     case 'showLoginOnFooter':


### PR DESCRIPTION
Display navbar Admin menu to Managers, if separate menu enabled (#315).

There might be a good reason not to display this menu to Managers all the time, but I can't think of one...? Access to admin plugins doesn't - and shouldn't - depend on whether or not the separate menu is displayed, so this seems to me to be a fairly safe thing to provide from a security standpoint.