### PR TITLE
Use PDF icon for ODT plugins ODT=>PDF export action

### DIFF
--- a/tpl_functions.php
+++ b/tpl_functions.php
@@ -201,6 +201,7 @@ function bootstrap3_toolsevent($toolsname, $items, $view='main', $return = false
           break;
 
         case 'export_pdf':
+        case 'export_odt_pdf':
           $icon = 'file-pdf-o';
           break;
 


### PR DESCRIPTION
Newer versions of the ODT plugin provide an alternative PDF export via the "export_odt_pdf" action. Use the same icon for this as for the "export_pdf" action of the dw2pdf plugin.

I don't think there will be many people using both the odt plugin PDF export and the dw2pdf plugin at the same time, so using the same icon should be ok.