### PR TITLE
Update simplenavi.less

### DIFF
--- a/css/plugins/simplenavi.less
+++ b/css/plugins/simplenavi.less
@@ -7,11 +7,11 @@
  */
 
 /* Simplenavi Plugin */
-.plugin__simplenavi ul {
+.plugin__simplenavi>ul {
 
   padding-left: 0 !important;
 
-  & ul ul {
+  & ul {
     padding-left: 10px !important;
   }
 


### PR DESCRIPTION
After the Greebo update, SimpleNavi appears to be display one less ul element than it was before. The proposed changes force the initial statement to be applied to the first ul element directly under the .plugin__simplenavi class, and every following ul element under that initial selector receives an additional +10px padding, rather than statically setting the selectors to ignore a set number of ul elements.