### PR TITLE
Simplify cookie handling of cookieNoticeAccepted

### DIFF
--- a/js/template.js
+++ b/js/template.js
@@ -670,7 +670,7 @@ jQuery(document).on('bootstrap3:dropdown-page', function() {
 jQuery(document).on('bootstrap3:cookie-law', function() {
   jQuery('#cookieDismiss').click(function(){
     jQuery('#cookieNotice').hide();
-    DokuCookie.setValue('cookieNoticeAccepted', true);
+    DokuCookie.setValue('cookieNoticeAccepted', 1);
   });
 });
 

--- a/tpl_cookielaw.php
+++ b/tpl_cookielaw.php
@@ -10,7 +10,7 @@
 // must be run from within DokuWiki
 if (!defined('DOKU_INC')) die();
 
-if ( bootstrap3_conf('showCookieLawBanner') && ! (get_doku_pref('cookieNoticeAccepted', null) || get_doku_pref('cookieNoticeAccepted', '')) ):
+if ( bootstrap3_conf('showCookieLawBanner') && !get_doku_pref('cookieNoticeAccepted', null) ):
 
 $cookie_policy_page_id = bootstrap3_conf('cookieLawPolicyPage');
 $cookie_banner_page_id = bootstrap3_conf('cookieLawBannerPage');


### PR DESCRIPTION
`get_doku_pref`'s second parameter is a default value, so there is no need to execute it twice; also in Javascript it's better to give this value as number, instead of boolean, because it gets converted into string in cookie.