### PR TITLE
added note about required PHP module `php-xml` to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,8 @@ If you install this template manually, make sure it is installed in
 `lib/tpl/bootstrap3/` - if the folder is called different it
 will not work!
 
+Ensure that the following PHP modules are installed: `php-xml`.
+
 Please refer to https://www.dokuwiki.org/template for additional info
 on how to install templates in DokuWiki.
 


### PR DESCRIPTION
Based on #420, I added a note to the README specifying that the PHP module `php-xml` needs to be installed (to avoid blank pages).