### PR TITLE
FIX: The permalink is inconsistent with standard URL when `userewrite` setting enabled

### DIFF
--- a/inc/Menu/Item/Permalink.php
+++ b/inc/Menu/Item/Permalink.php
@@ -29,7 +29,7 @@ class Permalink extends AbstractItem
         global $ID;
         global $INFO;
 
-        return wl($ID, 'rev=' . $INFO['lastmod'], true);
+        return wl($ID, 'rev=' . $INFO['lastmod'], true, '&');
     }
 
     public function getLinkAttributes($classprefix = 'menuitem ')

--- a/inc/Menu/Item/Permalink.php
+++ b/inc/Menu/Item/Permalink.php
@@ -29,7 +29,7 @@ class Permalink extends AbstractItem
         global $ID;
         global $INFO;
 
-        return DOKU_URL . DOKU_SCRIPT . '?id=' . $ID . '&rev=' . $INFO['lastmod'];
+        return wl($ID, 'rev=' . $INFO['lastmod'], true);
     }
 
     public function getLinkAttributes($classprefix = 'menuitem ')


### PR DESCRIPTION
When `userewrite` is `none`, the permalink URL is `example.com/doku.php?id=welcome&rev=1757323619` , that's correct.

If `userewrite` is `.htaccess`, the permalink URL is still `example.com/doku.php?id=welcome&rev=1757323619` . But it should be `example.com/welcome?rev=1757323619`.

If `userewrite` is `DokuWiki Internal`, It should be `example.com/doku.php/welcome?rev=1757323619`.

I fixed this to provide a uniform URL format.