### PR TITLE
Add accessible name to navbar toggle button

### DIFF
--- a/tpl/navbar.php
+++ b/tpl/navbar.php
@@ -25,7 +25,7 @@ $home_link        = ($TPL->getConf('homePageURL') ? $TPL->getConf('homePageURL')
 
         <div class="navbar-header">
 
-            <button class="navbar-toggle" type="button" data-toggle="collapse" data-target=".navbar-collapse">
+            <button class="navbar-toggle" aria-label="Navigation bar toggle" type="button" data-toggle="collapse" data-target=".navbar-collapse">
                 <span class="icon-bar"></span>
                 <span class="icon-bar"></span>
                 <span class="icon-bar"></span>


### PR DESCRIPTION
The hamburger menu button lacked inner text or an aria-label, causing it to be reported as "Buttons do not have an accessible name" in Lighthouse. Added aria-label to ensure screen readers announce the button's purpose.