### PR TITLE
Fix(Template.php): Trying to access array offset on false (issue #625)

### DIFF
--- a/Template.php
+++ b/Template.php
@@ -586,8 +586,8 @@ class Template
                     if ($this->getConf('useAvatar')) {
                         global $auth;
                         $user_data = $auth->getUserData($INFO['editor']);
-
-                        $avatar_img = $this->getAvatar($INFO['editor'], $user_data['mail'], 16);
+                        $user_mail = $user_data ? $user_data['mail'] : '';
+                        $avatar_img = $this->getAvatar($INFO['editor'], $user_mail, 16);
                         $user_img   = '<img src="' . $avatar_img . '" alt="" width="16" height="16" class="img-rounded" /> ';
                         $user       = str_replace(['iw_user', 'interwiki'], '', $user);
                         $user       = $user_img . "<bdi>$user<bdi>";


### PR DESCRIPTION
Resolve issue #625.

## "Trying to access array offset on false" when editing any page

### Versions

* Bootstrap3 Template - 2025-06-13
* DokuWiki - Librarian (b)
* PHP - 8.4.16
* Browser - Brave 1.88.132

### Log

```log
2026-03-16 15:21:56 .../lib/tpl/bootstrap3/Template.php(590)   E_WARNING: Trying to access array offset on false
  74   │   #0 .../lib/tpl/bootstrap3/Template.php(590): dokuwiki\ErrorHandler::errorHandler()
  75   │   #1 .../lib/tpl/bootstrap3/main.php(157): dokuwiki\template\bootstrap3\Template->getPageInfo()
  76   │   #2 .../inc/actions.php(30): include('...')
  77   │   #3 .../doku.php(131): act_dispatch()
  78   │   #4 {main}
```

## Fix

Replace line `590` in `Template.php`:

```php
$avatar_img = $this->getAvatar($INFO['editor'], $user_data['mail'] , 16);
```

Here, if there's no user, it tries to get an email that don't exist.

by:

```php
$user_mail = $user_data ? $user_data['mail'] : '';
$avatar_img = $this->getAvatar($INFO['editor'], $user_mail, 16);
```

Here, if `$user_data` (user) exist, use `$user_data['mail']`, else use `empty` string.